### PR TITLE
Bump Github CI node version to from 16.x to 18.x

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: |
           yarn
           make build && yarn publish --tag=latest


### PR DESCRIPTION
#### What this PR does / why we need it:

0.1.3 release failing on Node version so bumping it to 18.x
> error license-checker-rseidelsohn@4.3.0: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.20.2"

https://github.com/DataDog/datadog-eks-blueprints-addon/actions/runs/8806515499/job/24172384393

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
